### PR TITLE
Backend Jobs fixing and refactoring:

### DIFF
--- a/qiskit/_result.py
+++ b/qiskit/_result.py
@@ -71,17 +71,19 @@ class Result(object):
         Raises:
             QISKitError: if the Results cannot be combined.
         """
-        # TODO: reevaluate if moving equality to Backend themselves (part of
+        # todo: reevaluate if moving equality to Backend themselves (part of
         # a bigger problem - backend instances will not persist between
         # sessions)
-        self._result['result'] += other._result['result']
-        return self
+        this_backend = self._result.get('backend_name')
+        other_backend = other._result.get('backend_name')
+        if this_backend == other_backend:
+            self._result['result'] += other._result['result']
+            return self
+        else:
+            raise QISKitError('Result objects from different backends cannot be combined.')
 
     def __add__(self, other):
         """Combine Result objects.
-
-        Note that the qobj id of the returned result will be the same as the
-        first result.
 
         Arg:
             other (Result): a Result object to combine.

--- a/qiskit/_result.py
+++ b/qiskit/_result.py
@@ -24,7 +24,6 @@ class Result(object):
 
     Internal::
 
-        qobj =  { -- the quantum object that was complied --}
         result = {
             "job_id": --job-id (string),
                       #This string links the result with the job that computes it,
@@ -45,9 +44,8 @@ class Result(object):
             }
     """
 
-    def __init__(self, qobj_result, qobj):
+    def __init__(self, qobj_result):
         self._result = qobj_result
-        self._qobj = qobj
 
     def __str__(self):
         """Get the status of the run.
@@ -76,20 +74,8 @@ class Result(object):
         # TODO: reevaluate if moving equality to Backend themselves (part of
         # a bigger problem - backend instances will not persist between
         # sessions)
-        my_config = copy.deepcopy(self._qobj['config'])
-        other_config = copy.deepcopy(other._qobj['config'])
-        my_backend = my_config.pop('backend_name')
-        other_backend = other_config.pop('backend_name')
-
-        if my_config == other_config and my_backend == other_backend:
-            if isinstance(self._qobj['id'], str):
-                self._qobj['id'] = [self._qobj['id']]
-            self._qobj['id'].append(other._qobj['id'])
-            self._qobj['circuits'] += other._qobj['circuits']
-            self._result['result'] += other._result['result']
-            return self
-        else:
-            raise QISKitError('Result objects have different configs and cannot be combined.')
+        self._result['result'] += other._result['result']
+        return self
 
     def __add__(self, other):
         """Combine Result objects.
@@ -110,7 +96,7 @@ class Result(object):
         return self._result['status'] == 'ERROR'
 
     def get_status(self):
-        """Return whole qobj result status."""
+        """Return whole result status."""
         return self._result['status']
 
     def circuit_statuses(self):
@@ -152,10 +138,9 @@ class Result(object):
             QISKitError: if the circuit was not found.
         """
         try:
-            qobj = self._qobj
-            for index in range(len(qobj["circuits"])):
-                if qobj["circuits"][index]['name'] == name:
-                    return qobj["circuits"][index]["compiled_circuit_qasm"]
+            for exp_result in self._result['result']:
+                if exp_result.get('name') == name:
+                    return exp_result['compiled_circuit_qasm']
         except KeyError:
             pass
         raise QISKitError('No  qasm for circuit "{0}"'.format(name))
@@ -211,9 +196,8 @@ class Result(object):
             circuit = circuit.name
 
         if circuit is None:
-            circuits = list([i['name'] for i in self._qobj['circuits']])
-            if len(circuits) == 1:
-                circuit = circuits[0]
+            if len(self._result['result']) == 1:
+                return self._result['result'][0]['data']
             else:
                 raise QISKitError("You have to select a circuit when there is more than"
                                   "one available")
@@ -221,10 +205,9 @@ class Result(object):
         if not isinstance(circuit, str):
             circuit = str(circuit)
         try:
-            qobj = self._qobj
-            for index in range(len(qobj['circuits'])):
-                if qobj['circuits'][index]['name'] == circuit:
-                    return self._result['result'][index]['data']
+            for circuit_result in self._result['result']:
+                if circuit_result.get('name') == circuit:
+                    return circuit_result['data']
         except (KeyError, TypeError):
             pass
         raise QISKitError('No data for circuit "{0}"'.format(circuit))
@@ -365,7 +348,7 @@ class Result(object):
         Returns:
             List: A list of circuit names.
         """
-        return [c['name'] for c in self._qobj['circuits']]
+        return [c.get('name') for c in self._result['result']]
 
     def average_data(self, name, observable):
         """Compute the mean value of an diagonal observable.
@@ -390,12 +373,13 @@ class Result(object):
                 temp += counts[key] * observable[key] / tot
         return temp
 
-    def get_qubitpol_vs_xval(self, xvals_dict=None):
+    def get_qubitpol_vs_xval(self, nqubits, xvals_dict=None):
         """Compute the polarization of each qubit for all circuits and pull out each circuits
         xval into an array. Assumes that each circuit has the same number of qubits and that
         all qubits are measured.
 
         Args:
+            nqubits (int): number of qubits
             xvals_dict (dict): xvals for each circuit {'circuitname1': xval1,...}. If this
             is none then the xvals list is just left as an array of zeros
 
@@ -403,9 +387,8 @@ class Result(object):
             qubit_pol: mxn double array where m is the number of circuit, n the number of qubits
             xvals: mx1 array of the circuit xvals
         """
-        ncircuits = len(self._qobj['circuits'])
+        ncircuits = len(self._result['result'])
         # Is this the best way to get the number of qubits?
-        nqubits = self._qobj['circuits'][0]['compiled_circuit']['header']['number_of_qubits']
         qubitpol = numpy.zeros([ncircuits, nqubits], dtype=float)
         xvals = numpy.zeros([ncircuits], dtype=float)
 
@@ -421,10 +404,11 @@ class Result(object):
 
         # go through each circuit and for eqch qubit and apply the operators using "average_data"
         for circuit_ind in range(ncircuits):
+            circuit_name = self._result['result'][circuit_ind]['name']
             if xvals_dict:
-                xvals[circuit_ind] = xvals_dict[self._qobj['circuits'][circuit_ind]['name']]
+                xvals[circuit_ind] = xvals_dict[circuit_name]
             for qubit_ind in range(nqubits):
                 qubitpol[circuit_ind, qubit_ind] = self.average_data(
-                    self._qobj['circuits'][circuit_ind]['name'], z_dicts[qubit_ind])
+                    circuit_name, z_dicts[qubit_ind])
 
         return qubitpol, xvals

--- a/qiskit/backends/__init__.py
+++ b/qiskit/backends/__init__.py
@@ -9,4 +9,4 @@
 from .basebackend import BaseBackend
 from .baseprovider import BaseProvider
 from .basejob import BaseJob
-from .basejob import JobStatus
+from .jobstatus import JobStatus

--- a/qiskit/backends/__init__.py
+++ b/qiskit/backends/__init__.py
@@ -9,3 +9,4 @@
 from .basebackend import BaseBackend
 from .baseprovider import BaseProvider
 from .basejob import BaseJob
+from .basejob import JobStatus

--- a/qiskit/backends/basejob.py
+++ b/qiskit/backends/basejob.py
@@ -12,7 +12,6 @@ job interface.
 """
 
 from abc import ABC, abstractmethod
-import enum
 
 
 class BaseJob(ABC):
@@ -58,13 +57,3 @@ class BaseJob(ABC):
     def cancelled(self):
         """True if call was successfully cancelled"""
         pass
-
-
-class JobStatus(enum.Enum):
-    """Class for job status enumerated type."""
-    INITIALIZING = 'job is being initialized'
-    QUEUED = 'job is queued'
-    RUNNING = 'job is actively running'
-    CANCELLED = 'job has been cancelled'
-    DONE = 'job has successfully run'
-    ERROR = 'job incurred error'

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -156,12 +156,12 @@ class IBMQBackend(BaseBackend):
         backend_name = self.configuration['name']
         job_list = []
         base_index = skip
-        job_info_list = self._api.get_jobs(limit=limit, skip=base_index,
-                                           backend=backend_name)
+        job_info_list = []
         if isinstance(status, str):
             status = JobStatus[status]
         while len(job_list) < limit or len(job_info_list) < limit:
-            base_index += limit
+            job_info_list = self._api.get_jobs(limit=limit, skip=base_index,
+                                               backend=backend_name)
             for job_info in job_info_list:
                 is_device = not bool(self._configuration.get('simulator'))
                 job = IBMQJob.from_api(job_info, self._api, is_device)
@@ -170,8 +170,7 @@ class IBMQBackend(BaseBackend):
                         job_list.append(job)
                     elif job.status.get('status') == status:
                         job_list.append(job)
-            job_info_list = self._api.get_jobs(limit=limit, skip=base_index,
-                                               backend=backend_name)
+            base_index += limit
         return job_list
 
     def retrieve_job(self, job_id):

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -139,3 +139,25 @@ class IBMQBackend(BaseBackend):
             raise LookupError(
                 "Couldn't get backend status: {0}".format(ex))
         return status
+
+    def jobs(self, limit=50, skip=0):
+        """Attempt to get the jobs submitted to the backend
+
+        Args:
+            limit (int): number of jobs to retrieve
+            skip (int): starting index of retrieval
+
+        Return:
+            list(IBMQJob): list of IBMQJob instances
+        """
+        backend_name = self.configuration['name']
+        job_list = []
+        base_index = 0
+        job_info_list = self._api.get_jobs(limit=limit, skip=base_index)
+        while len(job_list) < limit or len(job_info_list) < limit:
+            base_index += skip
+            job_info_list = self._api.get_jobs(limit=limit, skip=base_index)
+            for job_info in job_info_list:
+                if job_info.get('backend').get('name') == backend_name:
+                    job_list.append(IBMQJob.from_api(job_info))
+        return job_list

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -14,6 +14,7 @@ import logging
 from qiskit import QISKitError
 from qiskit._util import _camel_case_to_snake_case
 from qiskit.backends import BaseBackend
+from qiskit.backends import JobStatus
 from qiskit.backends.ibmq.ibmqjob import IBMQJob
 
 logger = logging.getLogger(__name__)

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 class IBMQBackend(BaseBackend):
     """Backend class interfacing with the Quantum Experience remotely.
     """
-    
+
     def __init__(self, configuration, api=None):
         """Initialize remote backend for IBM Quantum Experience.
 
@@ -148,12 +148,12 @@ class IBMQBackend(BaseBackend):
             limit (int): number of jobs to retrieve
             skip (int): starting index of retrieval
 
-        Return:
+        Returns:
             list(IBMQJob): list of IBMQJob instances
         """
         backend_name = self.configuration['name']
         job_list = []
-        base_index = 0
+        base_index = skip
         job_info_list = self._api.get_jobs(limit=limit, skip=base_index)
         while len(job_list) < limit or len(job_info_list) < limit:
             base_index += limit
@@ -167,13 +167,24 @@ class IBMQBackend(BaseBackend):
         return job_list
 
     def retrieve_job(self, job_id):
-        """Attempt to get the specified job by job_id"""
+        """Attempt to get the specified job by job_id
+
+        Args:
+            job_id (str): the job id of the job to retrieve
+
+        Returns:
+            IBMQJob: class instance
+
+        Raises:
+            IBMQBackendError: if retrieval failed
+        """
         job_info = self._api.get_job(job_id)
         if 'error' in job_info:
             raise IBMQBackendError('failed to get job id "{}"'.format(job_id))
         is_device = not bool(self._configuration.get('simulator'))
         job = IBMQJob.from_api(job_info, self._api, is_device)
         return job
+
 
 class IBMQBackendError(QISKitError):
     """IBM Q Backend Errors"""

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -147,7 +147,8 @@ class IBMQBackend(BaseBackend):
         Args:
             limit (int): number of jobs to retrieve
             skip (int): starting index of retrieval
-            status (None or JobStatus): only get jobs with this status.
+            status (None or JobStatus or str): only get jobs with this status,
+                where status is e.g. JobStatus.RUNNING or 'RUNNING'.
         Returns:
             list(IBMQJob): list of IBMQJob instances
         """
@@ -156,6 +157,8 @@ class IBMQBackend(BaseBackend):
         base_index = skip
         job_info_list = self._api.get_jobs(limit=limit, skip=base_index,
                                            backend=backend_name)
+        if isinstance(status, str):
+            status = JobStatus[status]
         while len(job_list) < limit or len(job_info_list) < limit:
             base_index += limit
             job_info_list = self._api.get_jobs(limit=limit, skip=base_index)

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -162,7 +162,6 @@ class IBMQBackend(BaseBackend):
             status = JobStatus[status]
         while len(job_list) < limit or len(job_info_list) < limit:
             base_index += limit
-            job_info_list = self._api.get_jobs(limit=limit, skip=base_index)
             for job_info in job_info_list:
                 is_device = not bool(self._configuration.get('simulator'))
                 job = IBMQJob.from_api(job_info, self._api, is_device)
@@ -171,6 +170,8 @@ class IBMQBackend(BaseBackend):
                         job_list.append(job)
                     elif job.status.get('status') == status:
                         job_list.append(job)
+            job_info_list = self._api.get_jobs(limit=limit, skip=base_index,
+                                               backend=backend_name)
         return job_list
 
     def retrieve_job(self, job_id):

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -484,5 +484,4 @@ def _numpy_type_converter(obj):
         return float(obj)
     elif isinstance(obj, numpy.ndarray):
         return obj.tolist()
-    else:
-        return obj
+    return obj

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -362,17 +362,18 @@ class IBMQJob(BaseJob):
         # logger.info('Running qobj: %s on remote backend %s with job id: %s',
         #             qobj["id"], qobj['config']['backend_name'],
         #             job_id)
-        timer = 0
+        start_time = time.time()
         api_result = self._api.get_job(job_id)
         while not (self.done or self.cancelled or self.exception or
                    self._status == JobStatus.ERROR):
-            if timeout is not None and timer >= timeout:
+            elapsed_time = time.time() - start_time
+            if timeout is not None and elapsed_time >= timeout:
                 job_result = {'job_id': job_id, 'status': 'ERROR',
                               'result': 'QISkit Time Out'}
                 return Result(job_result)
             time.sleep(wait)
-            timer += wait
-            logger.info('status = %s (%d seconds)', api_result['status'], timer)
+            logger.info('status = %s (%d seconds)', api_result['status'],
+                        elapsed_time)
             api_result = self._api.get_job(job_id)
 
             if 'status' not in api_result:
@@ -483,3 +484,5 @@ def _numpy_type_converter(obj):
         return float(obj)
     elif isinstance(obj, numpy.ndarray):
         return obj.tolist()
+    else:
+        return obj

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -29,12 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 class IBMQJob(BaseJob):
-    """IBM Q Job class
-
-    Attributes:
-        _executor (futures.Executor): executor to handle asynchronous jobs
-    """
-    _executor = futures.ThreadPoolExecutor()
+    """IBM Q Job class """
 
     def __init__(self, q_job, api, is_device):
         """IBMQJob init function.
@@ -45,19 +40,25 @@ class IBMQJob(BaseJob):
             is_device (bool): whether backend is a real device  # TODO: remove this after Qobj
         """
         super().__init__()
-        self._q_job = q_job
-        self._qobj = q_job.qobj
+        qobj = q_job.qobj
+        self._job_data = {
+            'circuits': qobj['circuits'],
+            'hpc':  None if 'hpc' not in qobj['config'] else qobj['config']['hpc'],
+            'seed': qobj['circuits'][0]['config']['seed'],  # TODO <-- [0] ???
+            'shots': qobj['config']['shots'],
+            'max_credits': qobj['config']['max_credits']
+        }
         self._api = api
-        self._job_id = None  # this must be before creating the future
-        self._backend_name = self._qobj.get('config').get('backend_name')
+        self._job_id = None
+        self._backend_name = qobj.get('config').get('backend_name')
         self._status = JobStatus.INITIALIZING
-        self._future_submit = self._executor.submit(self._submit)
         self._status_msg = None
         self._cancelled = False
-        self._exception = None
         self._is_device = is_device
-        self._from_api = False
-        self.creation_date = None
+        self._queue_position = 0
+        self._creation_date = None
+        self._executor = futures.ThreadPoolExecutor()
+        self._future = None
 
     @classmethod
     def from_api(cls, job_info, api, is_device):
@@ -88,21 +89,22 @@ class IBMQJob(BaseJob):
             IBMQJob: an instance of this class
         """
         job_instance = cls.__new__(cls)
-        job_instance._status = JobStatus.QUEUED
+        job_instance._is_device = is_device
+        job_instance._cancelled = False
+        job_instance._status_msg = None
+        job_instance._queue_position = 0
+        job_instance._executor = futures.ThreadPoolExecutor()
+        job_instance._future = None
         job_instance._backend_name = job_info.get('backend').get('name')
         job_instance._api = api
         job_instance._job_id = job_info.get('id')
-        job_instance._exception = None  # needs to be before status call below
         # update status (need _api and _job_id)
         # pylint: disable=pointless-statement
+        job_instance._creation_date = job_info.get('creationDate')
         job_instance.status
-        job_instance._status_msg = None
-        job_instance._cancelled = False
-        job_instance._is_device = is_device
-        job_instance._from_api = True
-        job_instance.creation_date = job_info.get('creationDate')
         return job_instance
 
+    # pylint: disable=arguments-differ
     def result(self, timeout=None, wait=5):
         """Return the result from the job.
 
@@ -116,39 +118,30 @@ class IBMQJob(BaseJob):
         Raises:
             IBMQJobError: exception raised during job initialization
         """
-        # pylint: disable=arguments-differ
-        while self._status == JobStatus.INITIALIZING:
-            if self._future_submit.exception():
-                raise IBMQJobError('error submitting job: {}'.format(
-                    repr(self._future_submit.exception())))
-            time.sleep(0.1)
+        self._wait_for_submitting()
         this_result = self._wait_for_job(timeout=timeout, wait=wait)
-        if self._is_device and self.done:
+        if self._is_device:
             _reorder_bits(this_result)
-        if this_result.get_status() == 'ERROR':
-            self._status = JobStatus.ERROR
-        else:
-            self._status = JobStatus.DONE
         return this_result
 
     def cancel(self):
-        """Attempt to cancel job. Currently this is only possible on
-        commercial systems.
+        """Attempt to cancel job.
+           TODO: Currently this is only possible on commercial systems.
         Returns:
             bool: True if job can be cancelled, else False.
 
         Raises:
-            QISKitError: if server returned error
+            IBMQJobError: if server returned error
         """
-        if self._is_commercial:
+        self._wait_for_submitting()
+        if self._is_commercial():
             hub = self._api.config['hub']
             group = self._api.config['group']
             project = self._api.config['project']
             response = self._api.cancel_job(self._job_id, hub, group, project)
             if 'error' in response:
                 err_msg = response.get('error', '')
-                self._exception = QISKitError('Error cancelling job: %s' % err_msg)
-                raise QISKitError('Error canceelling job: %s' % err_msg)
+                raise IBMQJobError('Error cancelling job: %s' % err_msg)
             else:
                 self._cancelled = True
                 return True
@@ -158,50 +151,45 @@ class IBMQJob(BaseJob):
 
     @property
     def status(self):
-        if self._status == JobStatus.INITIALIZING:
-            stats = {'job_id': None,
-                     'status': self._status,
-                     'status_msg': 'job is begin initialized please wait a moment'}
-            return stats
-        job_result = self._api.get_job(self._job_id)
-        stats = {'job_id': self._job_id}
-        self._status = None
-        _status_msg = None
-        if 'status' not in job_result:
-            self._exception = QISKitError("get_job didn't return status: %s" %
-                                          (pprint.pformat(job_result)))
-            raise QISKitError("get_job didn't return status: %s" %
-                              (pprint.pformat(job_result)))
-        elif job_result['status'] == 'RUNNING':
+        """ Query the API for the status of the Job """
+        self._wait_for_submitting()
+        api_job = self._api.get_job(self._job_id)
+        if 'status' not in api_job:
+            raise IBMQJobError("get_job didn't return status: %s" %
+                               (pprint.pformat(api_job)))
+        elif api_job['status'] == 'RUNNING':
             self._status = JobStatus.RUNNING
             # we may have some other information here
-            if 'infoQueue' in job_result:
-                if 'status' in job_result['infoQueue']:
-                    if job_result['infoQueue']['status'] == 'PENDING_IN_QUEUE':
+            if 'infoQueue' in api_job:
+                if 'status' in api_job['infoQueue']:
+                    if api_job['infoQueue']['status'] == 'PENDING_IN_QUEUE':
                         self._status = JobStatus.QUEUED
-                if 'position' in job_result['infoQueue']:
-                    stats['queue_position'] = job_result['infoQueue']['position']
-        elif job_result['status'] == 'COMPLETED':
+                if 'position' in api_job['infoQueue']:
+                    self._queue_position = api_job['infoQueue']['position']
+        elif api_job['status'] == 'COMPLETED':
             self._status = JobStatus.DONE
-        elif job_result['status'] == 'CANCELLED':
+        elif api_job['status'] == 'CANCELLED':
+            self._cancelled = True
             self._status = JobStatus.CANCELLED
-        elif self.exception or self._future_submit.exception():
-            self._status = JobStatus.ERROR
-            if self._future_submit.exception():
-                self._exception = self._future_submit.exception()
-            self._status_msg = str(self.exception)
-        elif 'ERROR' in job_result['status']:
+        elif 'ERROR' in api_job['status']:
             # ERROR_CREATING_JOB or ERROR_RUNNING_JOB
             self._status = JobStatus.ERROR
-            self._status_msg = job_result['status']
+            self._status_msg = api_job['status']
         else:
             self._status = JobStatus.ERROR
             raise IBMQJobError('Unexpected behavior of {0}\n{1}'.format(
                 self.__class__.__name__,
-                pprint.pformat(job_result)))
-        stats['status'] = self._status
-        stats['status_msg'] = _status_msg
-        return stats
+                pprint.pformat(api_job)))
+        return self._status
+
+    def queue_position(self):
+        """
+        Returns the position in the server queue
+
+        Returns:
+            Number: Position in the queue. 0 = No queued.
+        """
+        return self._queue_position
 
     @property
     def queued(self):
@@ -214,7 +202,7 @@ class IBMQJob(BaseJob):
         Raises:
             QISKitError: couldn't get job status from server
         """
-        return self.status['status'] == JobStatus.QUEUED
+        return self.status == JobStatus.QUEUED
 
     @property
     def running(self):
@@ -225,9 +213,9 @@ class IBMQJob(BaseJob):
             bool: True if job is running, else False.
 
         Raises:
-            QISKitError: couldn't get job status from server
+            IBMQJobError: couldn't get job status from server
         """
-        return self.status['status'] == JobStatus.RUNNING
+        return self.status == JobStatus.RUNNING
 
     @property
     def done(self):
@@ -237,38 +225,18 @@ class IBMQJob(BaseJob):
         Note behavior is slightly different than Future objects which would
         also return true if successfully cancelled.
         """
-        return self.status['status'] == JobStatus.DONE
+        return self.status == JobStatus.DONE
 
     @property
     def cancelled(self):
         return self._cancelled
 
     @property
-    def exception(self):
-        """
-        Return Exception object previously raised by job else None
-
-        Returns:
-            Exception: exception raised by job
-        """
-        if isinstance(self._exception, Exception):
-            self._status_msg = str(self._exception)
-        return self._exception
-
-    @property
-    def _is_commercial(self):
-        config = self._api.config
-        # this check may give false positives so should probably be improved
-        return config.get('hub') and config.get('group') and config.get('project')
-
-    @property
     def job_id(self):
         """
-        Return backend determined job_id (also available in status method).
+        Return backend determined job_id.
         """
-        while not self._job_id:
-            # job is initializing and hasn't gotten a job_id yet.
-            time.sleep(0.1)
+        self._wait_for_submitting()
         return self._job_id
 
     @property
@@ -278,11 +246,49 @@ class IBMQJob(BaseJob):
         """
         return self._backend_name
 
-    def _submit(self):
+    def submit(self):
+        """ Submits a Job to the concurrent pool executor """
+        if self._future is not None:
+            raise IBMQJobError("We have already submitted a job!")
+
+        hpc = self._job_data['hpc']
+        seed = self._job_data['seed']
+        shots = self._job_data['shots']
+        max_credits = self._job_data['max_credits']
+
+        api_jobs = []
+        if 'circuits' in self._job_data:
+            circuits = self._job_data['circuits']
+            for circuit in circuits:
+                job = _create_job_from_circuit(circuit)
+                api_jobs.append(job)
+
+        hpc_camel_cased = None
+        if hpc is not None:
+            try:
+                # Use CamelCase when passing the hpc parameters to the API.
+                hpc_camel_cased = {
+                    'multiShotOptimization': hpc['multi_shot_optimization'],
+                    'ompNumThreads': hpc['omp_num_threads']
+                }
+            except (KeyError, TypeError):
+                hpc_camel_cased = None
+
+        self._future = self._executor.submit(self._submit_callback, api_jobs,
+                                             self._backend_name, hpc_camel_cased,
+                                             seed, shots, max_credits)
+
+    def _submit_callback(self, api_jobs, backend_name, hpc, seed, shots,
+                         max_credits):
         """Submit job to IBM Q.
 
-        Returns:
-            dict: submission info including job id from server
+        Parameters:
+            api_jobs (list): List of API Job dictionaries to submit. One per circuit.
+            backend_name (string): The name of the backend
+            hpc: HPC specific configuration
+            seed: The seed for the circuits
+            shots: Number of shots the circuits should run
+            max_credits: Maximum number of credits
 
         Raises:
             QISKitError: The backend name in the job doesn't match this backend.
@@ -290,62 +296,9 @@ class IBMQJob(BaseJob):
             RegisterSizeError: If the requested register size exceeded device
                 capability.
         """
-        qobj = self._qobj
-        api_jobs = []
-        for circuit in qobj['circuits']:
-            job = {}
-            if (('compiled_circuit_qasm' not in circuit) or
-                    (circuit['compiled_circuit_qasm'] is None)):
-                compiled_circuit = compile_circuit(circuit['circuit'])
-                circuit['compiled_circuit_qasm'] = compiled_circuit.qasm(qeflag=True)
-            if isinstance(circuit['compiled_circuit_qasm'], bytes):
-                job['qasm'] = circuit['compiled_circuit_qasm'].decode()
-            else:
-                job['qasm'] = circuit['compiled_circuit_qasm']
-            if 'name' in circuit:
-                job['name'] = circuit['name']
-            # convert numpy types for json serialization
-            compiled_circuit = json.loads(
-                json.dumps(circuit['compiled_circuit'],
-                           default=_numpy_type_converter))
-            job['metadata'] = {'compiled_circuit': compiled_circuit}
-            api_jobs.append(job)
-        seed0 = qobj['circuits'][0]['config']['seed']
-        hpc = None
-        if 'hpc' in qobj['config']:
-            try:
-                # Use CamelCase when passing the hpc parameters to the API.
-                hpc = {
-                    'multiShotOptimization':
-                        qobj['config']['hpc']['multi_shot_optimization'],
-                    'ompNumThreads':
-                        qobj['config']['hpc']['omp_num_threads']
-                }
-            except (KeyError, TypeError):
-                hpc = None
-        backend_name = qobj['config']['backend_name']
-        if backend_name != self._backend_name:
-            raise QISKitError("inconsistent qobj backend "
-                              "name ({0} != {1})".format(backend_name,
-                                                         self._backend_name))
-        submit_info = {}
-        try:
-            submit_info = self._api.run_job(api_jobs, backend=backend_name,
-                                            shots=qobj['config']['shots'],
-                                            max_credits=qobj['config']['max_credits'],
-                                            seed=seed0,
-                                            hpc=hpc)
-        # pylint: disable=broad-except
-        except Exception as err:
-            self._status = JobStatus.ERROR
-            self._exception = err
-        if 'error' in submit_info:
-            self._status = JobStatus.ERROR
-            self._exception = IBMQJobError(str(submit_info['error']))
-        self._job_id = submit_info.get('id')
-        self.creation_date = submit_info.get('creationDate')
-        self._status = JobStatus.QUEUED
-        return submit_info
+        return self._api.run_job(api_jobs, backend=backend_name,
+                                 shots=shots, max_credits=max_credits,
+                                 seed=seed, hpc=hpc)
 
     def _wait_for_job(self, timeout=60, wait=5):
         """Wait until all online ran circuits of a qobj are 'COMPLETED'.
@@ -359,70 +312,78 @@ class IBMQJob(BaseJob):
             Result: A result object.
 
         Raises:
-            QISKitError: job didn't return status or reported error in status
+            IBMQJobError: job didn't return status or reported error in status
         """
-        # qobj = self._q_job.qobj
-        job_id = self.job_id
-        # logger.info('Running qobj: %s on remote backend %s with job id: %s',
-        #             qobj["id"], qobj['config']['backend_name'],
-        #             job_id)
-        start_time = time.time()
-        api_result = self._api.get_job(job_id)
-        while not (self.done or self.cancelled or self.exception or
-                   self._status == JobStatus.ERROR):
-            elapsed_time = time.time() - start_time
-            if timeout is not None and elapsed_time >= timeout:
-                job_result = {'job_id': job_id, 'status': 'ERROR',
-                              'result': 'QISkit Time Out'}
-                return Result(job_result)
-            time.sleep(wait)
-            logger.info('status = %s (%d seconds)', api_result['status'],
-                        elapsed_time)
-            api_result = self._api.get_job(job_id)
+        timer = 0
+        job_result = JobResult(self._job_id, 'CANCELLED', '')
 
+        while not self._cancelled:
+            if timeout is not None and timer >= timeout:
+                job_result = JobResult(self._job_id, 'ERROR', 'QISkit Time Out')
+                break
+
+            api_result = self._api.get_job(self._job_id)
             if 'status' not in api_result:
-                self._exception = QISKitError("get_job didn't return status: %s" %
-                                              (pprint.pformat(api_result)))
-                raise QISKitError("get_job didn't return status: %s" %
-                                  (pprint.pformat(api_result)))
-            if (api_result['status'] == 'ERROR_CREATING_JOB' or
-                    api_result['status'] == 'ERROR_RUNNING_JOB'):
-                job_result = {'job_id': job_id, 'status': 'ERROR',
-                              'result': api_result['status']}
-                return Result(job_result)
+                raise IBMQJobError("get_job didn't return status: %s" %
+                                   (pprint.pformat(api_result)))
 
-        if self.cancelled:
-            job_result = {'job_id': job_id, 'status': 'CANCELLED',
-                          'result': 'job cancelled'}
-            return Result(job_result)
-        elif self.exception:
-            job_result = {'job_id': job_id, 'status': 'ERROR',
-                          'result': str(self.exception)}
-            return Result(job_result)
-        api_result = self._api.get_job(job_id)
-        job_result_list = []
-        for circuit_result in api_result['qasms']:
-            this_result = {'data': circuit_result['data'],
-                           'name': circuit_result.get('name'),
-                           'compiled_circuit_qasm': circuit_result.get('qasm'),
-                           'status': circuit_result['status']}
-            if 'metadata' in circuit_result:
-                this_result['metadata'] = circuit_result['metadata']
-            job_result_list.append(this_result)
-        job_result = {'job_id': job_id,
-                      'status': api_result['status'],
-                      'used_credits': api_result.get('usedCredits'),
-                      'result': job_result_list}
-        # logger.info('Got a result for qobj: %s from remote backend %s with job id: %s',
-        #             qobj["id"], qobj['config']['backend_name'],
-        #             job_id)
-        job_result['backend_name'] = self.backend_name
-        return Result(job_result)
+            if 'ERROR' in api_result['status'].upper():
+                logger.info('There was an error in the Job: status = %s', api_result['status'])
+                self._status = JobStatus.ERROR
+                job_result = JobResult(self._job_id, 'ERROR', api_result['status'])
+                break
 
+            if api_result['status'] == 'RUNNING':
+                logger.info('status = %s (%d seconds)', api_result['status'], timer)
+                time.sleep(wait)
+                timer += wait
+                continue
 
-class IBMQJobError(QISKitError):
-    """class for IBM Q Job errors"""
-    pass
+            if api_result['status'] == 'CANCELLED':
+                self._status = JobStatus.CANCELLED
+                job_result = JobResult(self._job_id, 'CANCELLED', api_result['status'])
+                logger.info('The job was cancelled!')
+                break
+
+            # After this point the job is completed!
+            logger.info('Job is complete! status = %s', api_result['status'])
+            job_result_list = []
+            for circuit_result in api_result['qasms']:
+                this_result = {'data': circuit_result['data'],
+                               'name': circuit_result.get('name'),
+                               'compiled_circuit_qasm': circuit_result.get('qasm'),
+                               'status': circuit_result['status']}
+                if 'metadata' in circuit_result:
+                    this_result['metadata'] = circuit_result['metadata']
+                job_result_list.append(this_result)
+
+            logger.info('Got a result from remote backend %s with job id: %s',
+                        self.backend_name, self._job_id)
+            job_result = JobResult(self._job_id, api_result['status'],
+                                   job_result_list,
+                                   api_result.get('usedCredits'),
+                                   backend_name=self._backend_name)
+            self._status = JobStatus.DONE
+            break
+
+        return Result(job_result.as_dict())
+
+    def _is_commercial(self):
+        config = self._api.config
+        # this check may give false positives so should probably be improved
+        return config.get('hub') and config.get('group') and config.get('project')
+
+    def _wait_for_submitting(self):
+        if self._job_id is None:
+            if self._future is None:
+                raise IBMQJobError("You have to submit before asking for status or results!")
+            submit_info = self._future.result(timeout=60)
+            if 'error' in submit_info:
+                raise IBMQJobError(str(submit_info['error']))
+
+            self._creation_date = submit_info.get('creationDate')
+            self._status = JobStatus.QUEUED
+            self._job_id = submit_info.get('id')
 
 
 def _reorder_bits(result):
@@ -430,15 +391,12 @@ def _reorder_bits(result):
     for every ran circuit, get reordering information from qobj
     and apply reordering on result"""
     for circuit_result in result._result['result']:
-        if 'metadata' in circuit_result:
-            circ = circuit_result['metadata'].get('compiled_circuit')
-        else:
-            logger.warning('result object missing metadata for reordering'
-                           ' bits: bits may be out of order')
-            return
+        if 'metadata' not in circuit_result:
+            raise QISKitError('result object missing metadata for reordering bits')
+
+        circ = circuit_result['metadata'].get('compiled_circuit')
         # device_qubit -> device_clbit (how it should have been)
-        measure_dict = {op['qubits'][0]: op['clbits'][0]
-                        for op in circ['operations']
+        measure_dict = {op['qubits'][0]: op['clbits'][0] for op in circ['operations']
                         if op['name'] == 'measure'}
         counts_dict_new = {}
         for item in circuit_result['data']['counts'].items():
@@ -491,3 +449,57 @@ def _numpy_type_converter(obj):
     elif isinstance(obj, numpy.ndarray):
         return obj.tolist()
     return obj
+
+
+def _create_job_from_circuit(circuit):
+    """ Helper function that creates a special Job required by the API, from a circuit
+    """
+    job = {}
+    if (('compiled_circuit_qasm' not in circuit) or
+            (circuit['compiled_circuit_qasm'] is None)):
+        compiled_circuit = compile_circuit(circuit['circuit'])
+        circuit['compiled_circuit_qasm'] = compiled_circuit.qasm(qeflag=True)
+
+    if isinstance(circuit['compiled_circuit_qasm'], bytes):
+        job['qasm'] = circuit['compiled_circuit_qasm'].decode()
+    else:
+        job['qasm'] = circuit['compiled_circuit_qasm']
+
+    if 'name' in circuit:
+        job['name'] = circuit['name']
+
+    # convert numpy types for json serialization
+    compiled_circuit = json.loads(json.dumps(circuit['compiled_circuit'],
+                                             default=_numpy_type_converter))
+    job['metadata'] = {'compiled_circuit': compiled_circuit}
+    return job
+
+
+class IBMQJobError(QISKitError):
+    """class for IBM Q Job errors"""
+    pass
+
+
+class JobResult:
+    """ Just a Helper class to encapsulate the results taken from a Job"""
+    def __init__(self, job_id, status, result, used_circuits=None,
+                 backend_name=None):
+        self._job_id = job_id
+        self._status = status
+        self._result = result
+        self._used_circuits = used_circuits
+        self._backend_name = backend_name
+
+    def as_dict(self):
+        """ Transforms into a dictionary """
+        ret = {
+            'job_id': self._job_id,
+            'status': self._status,
+            'result': self._result,
+        }
+        if self._used_circuits is not None:
+            ret['used_circuit'] = self._used_circuits
+        if self._backend_name is not None:
+            ret['backend_name'] = self._backend_name
+
+        return ret

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -273,15 +273,18 @@ class IBMQJob(BaseJob):
         qobj = self._qobj
         api_jobs = []
         for circuit in qobj['circuits']:
+            job = {}
             if (('compiled_circuit_qasm' not in circuit) or
                     (circuit['compiled_circuit_qasm'] is None)):
                 compiled_circuit = compile_circuit(circuit['circuit'])
                 circuit['compiled_circuit_qasm'] = compiled_circuit.qasm(qeflag=True)
             if isinstance(circuit['compiled_circuit_qasm'], bytes):
-                api_jobs.append({'qasm': circuit['compiled_circuit_qasm'].decode()})
+                job['qasm'] = circuit['compiled_circuit_qasm'].decode()
             else:
-                api_jobs.append({'qasm': circuit['compiled_circuit_qasm']})
-
+                job['qasm'] = circuit['compiled_circuit_qasm']
+            if 'name' in circuit:
+                job['name'] = circuit['name']
+            api_jobs.append(job)
         seed0 = qobj['circuits'][0]['config']['seed']
         hpc = None
         if 'hpc' in qobj['config']:

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -249,6 +249,9 @@ class IBMQJob(BaseJob):
         """
         Return backend determined job_id (also available in status method).
         """
+        while not self._job_id:
+            # job is initializing and hasn't gotten a job_id yet.
+            time.sleep(0.1)
         return self._job_id
 
     @property
@@ -305,7 +308,11 @@ class IBMQJob(BaseJob):
                                                          self._backend_name))
         submit_info = {}
         try:
-            submit_info = self._api.run_job(api_jobs, backend=backend_name)
+            submit_info = self._api.run_job(api_jobs, backend=backend_name,
+                                            shots=qobj['config']['shots'],
+                                            max_credits=qobj['config']['max_credits'],
+                                            seed=seed0,
+                                            hpc=hpc)
         except ApiError as err:
             self._status = JobStatus.ERROR
             self._exception = err

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -78,6 +78,7 @@ class IBMQJob(BaseJob):
                  'shots': 1024,
                  'status': 'status string',
                  'usedCredits': 3,
+                 'creationDate': '2018-06-13T04:31:13.175Z'
                  'userId': 'user id'}
             api (IBMQuantumExperience): IBM Q API
             is_device (bool): whether backend is a real device  # TODO: remove this after Qobj
@@ -98,6 +99,7 @@ class IBMQJob(BaseJob):
         job_instance._cancelled = False
         job_instance._is_device = is_device
         job_instance._from_api = True
+        job_instance.creationDate = job_info.get('creationDate')
         return job_instance
 
     def result(self, timeout=None, wait=5):
@@ -340,6 +342,7 @@ class IBMQJob(BaseJob):
             self._status = JobStatus.ERROR
             self._exception = IBMQJobError(str(submit_info['error']))
         self._job_id = submit_info.get('id')
+        self.creationDate = submit_info.get('creationDate')
         self._status = JobStatus.QUEUED
         return submit_info
 
@@ -429,7 +432,9 @@ def _reorder_bits(result):
         if 'metadata' in circuit_result:
             circ = circuit_result['metadata'].get('compiled_circuit')
         else:
-            raise QISKitError('result object missing metadata for reordering bits')
+            logger.warning('result object missing metadata for reordering'
+                           ' bits: bits may be out of order')
+            return
         # device_qubit -> device_clbit (how it should have been)
         measure_dict = {op['qubits'][0]: op['clbits'][0]
                         for op in circ['operations']

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -56,6 +56,42 @@ class IBMQJob(BaseJob):
         self._exception = None
         self._is_device = is_device
 
+    @classmethod
+    def from_api(self, job_info, api, is_device):
+        """Instantiates job using information returned from
+        IBMQuantumExperience about a particular job.
+
+        Args:
+            job_info (dict): This is the information about a job returned from
+                the API. It has the simplified structure:
+
+                {'backend': {'id', 'backend id string',
+                             'name', 'ibmqx4'},
+                 'id': 'job id string',
+                 'qasms': [{'executionId': 'id string',
+                            'qasm': 'qasm string'},
+                          ]
+                 'status': 'status string',
+                 'seed': '1',
+                 'shots': 1024,
+                 'status': 'status string',
+                 'usedCredits': 3,
+                 'userId': 'user id'}
+            api (IBMQuantumExperience): IBM Q API
+            is_device (bool): whether backend is a real device  # TODO: remove this after Qobj
+        """
+        super().__init__()
+        self._status = JobStatus.QUEUED
+        self._backend_name = job_info.get('backend').get('name')
+        self._api = api
+        self._job_id = job_info.get('id')
+        # update status (need _api and _job_id)
+        self.status
+        self._status_msg = None
+        self._cancelled = False
+        self._exception = None
+        self._is_device = is_device
+
     def result(self, timeout=None, wait=5):
         # pylint: disable=arguments-differ
         while self._status == JobStatus.INITIALIZING:

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -57,6 +57,7 @@ class IBMQJob(BaseJob):
         self._exception = None
         self._is_device = is_device
         self._from_api = False
+        self.creation_date = None
 
     @classmethod
     def from_api(cls, job_info, api, is_device):
@@ -99,7 +100,7 @@ class IBMQJob(BaseJob):
         job_instance._cancelled = False
         job_instance._is_device = is_device
         job_instance._from_api = True
-        job_instance.creationDate = job_info.get('creationDate')
+        job_instance.creation_date = job_info.get('creationDate')
         return job_instance
 
     def result(self, timeout=None, wait=5):
@@ -342,7 +343,7 @@ class IBMQJob(BaseJob):
             self._status = JobStatus.ERROR
             self._exception = IBMQJobError(str(submit_info['error']))
         self._job_id = submit_info.get('id')
-        self.creationDate = submit_info.get('creationDate')
+        self.creation_date = submit_info.get('creationDate')
         self._status = JobStatus.QUEUED
         return submit_info
 

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -19,7 +19,7 @@ import json
 import numpy
 
 from qiskit.backends import BaseJob
-from qiskit.backends.basejob import JobStatus
+from qiskit.backends.jobstatus import JobStatus
 from qiskit._qiskiterror import QISKitError
 from qiskit._result import Result
 from qiskit._resulterror import ResultError

--- a/qiskit/backends/jobstatus.py
+++ b/qiskit/backends/jobstatus.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2017, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""This module defines an enumerated type for the state of backend jobs"""
+
+import enum
+
+
+class JobStatus(enum.Enum):
+    """Class for job status enumerated type."""
+    INITIALIZING = 'job is being initialized'
+    QUEUED = 'job is queued'
+    RUNNING = 'job is actively running'
+    CANCELLED = 'job has been cancelled'
+    DONE = 'job has successfully run'
+    ERROR = 'job incurred error'

--- a/qiskit/backends/local/localjob.py
+++ b/qiskit/backends/local/localjob.py
@@ -12,7 +12,7 @@ import logging
 import sys
 
 from qiskit.backends import BaseJob
-from qiskit.backends.basejob import JobStatus
+from qiskit.backends import JobStatus
 from qiskit import QISKitError
 
 logger = logging.getLogger(__name__)

--- a/qiskit/backends/local/qasm_simulator_cpp.py
+++ b/qiskit/backends/local/qasm_simulator_cpp.py
@@ -78,7 +78,7 @@ class QasmSimulatorCpp(BaseBackend):
         qobj = q_job.qobj
         self._validate(qobj)
         result = run(qobj, self._configuration['exe'])
-        return Result(result, qobj)
+        return Result(result)
 
     def _validate(self, qobj):
         if qobj['config']['shots'] == 1:
@@ -147,7 +147,7 @@ class CliffordSimulatorCpp(BaseBackend):
             qobj['config'] = {'simulator': 'clifford'}
 
         result = run(qobj, self._configuration['exe'])
-        return Result(result, qobj)
+        return Result(result)
 
     def _validate(self):
         return

--- a/qiskit/backends/local/qasm_simulator_py.py
+++ b/qiskit/backends/local/qasm_simulator_py.py
@@ -290,7 +290,7 @@ class QasmSimulatorPy(BaseBackend):
                   'status': 'COMPLETED',
                   'success': True,
                   'time_taken': (end - start)}
-        return Result(result, qobj)
+        return Result(result)
 
     def run_circuit(self, circuit):
         """Run a circuit and return a single Result.

--- a/qiskit/backends/local/statevector_simulator_py.py
+++ b/qiskit/backends/local/statevector_simulator_py.py
@@ -79,7 +79,7 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
             # Remove snapshot dict if empty
             if snapshots == {}:
                 res['data'].pop('snapshots', None)
-        return Result(result, qobj)
+        return Result(result)
 
     def _validate(self, qobj):
         """Semantic validations of the qobj which cannot be done via schemas.

--- a/qiskit/backends/local/unitary_simulator_py.py
+++ b/qiskit/backends/local/unitary_simulator_py.py
@@ -166,8 +166,7 @@ class UnitarySimulatorPy(BaseBackend):
             result_list.append(self.run_circuit(circuit))
         job_id = str(uuid.uuid4())
         return Result(
-            {'job_id': job_id, 'result': result_list, 'status': 'COMPLETED'},
-            qobj)
+            {'job_id': job_id, 'result': result_list, 'status': 'COMPLETED'})
 
     def run_circuit(self, circuit):
         """Apply the single-qubit gate."""
@@ -175,6 +174,7 @@ class UnitarySimulatorPy(BaseBackend):
         self._number_of_qubits = ccircuit['header']['number_of_qubits']
         result = {}
         result['data'] = {}
+        result['name'] = circuit.get('name')
         self._unitary_state = np.identity(2**(self._number_of_qubits),
                                           dtype=complex)
         for operation in ccircuit['operations']:

--- a/qiskit/tools/file_io.py
+++ b/qiskit/tools/file_io.py
@@ -138,7 +138,6 @@ def load_result_from_file(filename):
         master_dict = json.load(load_file)
 
     try:
-        qobj = master_dict['qobj']
         qresult_dict = master_dict['result']
         convert_json_to_qobj(qresult_dict)
         metadata = master_dict['metadata']
@@ -146,7 +145,7 @@ def load_result_from_file(filename):
         raise QISKitError('File %s does not have the proper dictionary '
                           'structure')
 
-    qresult = qiskit.Result(qresult_dict, qobj)
+    qresult = qiskit.Result(qresult_dict)
 
     return qresult, metadata
 
@@ -172,8 +171,7 @@ class ResultEncoder(json.JSONEncoder):
 
 
 def save_result_to_file(resultobj, filename, metadata=None):
-    """Save a result (qobj + result) and optional metatdata
-    to a single dictionary file.
+    """Save a result and optional metatdata to a single dictionary file.
 
     Args:
         resultobj (Result): Result to save
@@ -189,7 +187,6 @@ def save_result_to_file(resultobj, filename, metadata=None):
         String: full file path
     """
     master_dict = {
-        'qobj': copy.deepcopy(resultobj._qobj),
         'result': copy.deepcopy(resultobj._result)
     }
     if metadata is None:

--- a/test/python/_dummybackend.py
+++ b/test/python/_dummybackend.py
@@ -19,7 +19,7 @@ import time
 from qiskit import Result
 from qiskit.backends import BaseBackend
 from qiskit.backends import BaseJob
-from qiskit.backends.basejob import JobStatus
+from qiskit.backends import JobStatus
 from qiskit.backends.baseprovider import BaseProvider
 
 logger = logging.getLogger(__name__)

--- a/test/python/_dummybackend.py
+++ b/test/python/_dummybackend.py
@@ -66,14 +66,14 @@ class DummySimulator(BaseBackend):
     def run(self, q_job):
         return DummyJob(self.run_job, q_job)
 
+    # pylint: disable=unused-argument
     def run_job(self, q_job):
         """ Main dummy simulator loop """
         job_id = str(uuid.uuid4())
-        qobj = q_job.qobj
 
         time.sleep(self.time_alive)
 
-        return Result({'job_id': job_id, 'result': [], 'status': 'COMPLETED'}, qobj)
+        return Result({'job_id': job_id, 'result': [], 'status': 'COMPLETED'})
 
 
 class DummyJob(BaseJob):

--- a/test/python/test_backends.py
+++ b/test/python/test_backends.py
@@ -111,6 +111,7 @@ class TestBackends(QiskitTestCase):
         remotes = ibmq_provider.available_backends({'local': False})
         remotes = remove_backends_from_list(remotes)
         for backend in remotes:
+            self.log.info(backend.status)
             status = backend.status
             schema_path = self._get_resource_path(
                 'deprecated/backends/backend_status_schema_py.json', path=Path.SCHEMAS)

--- a/test/python/test_compiler.py
+++ b/test/python/test_compiler.py
@@ -216,8 +216,9 @@ class TestCompiler(QiskitTestCase):
         qc.cx(qubit_reg[0], qubit_reg[1])
         qc.measure(qubit_reg, clbit_reg)
         qobj = qiskit._compiler.compile(qc, backend)
-        result = backend.run(qiskit.QuantumJob(qobj, backend=backend,
-                                               preformatted=True)).result()
+        job = backend.run(qiskit.QuantumJob(qobj, backend=backend,
+                                            preformatted=True))
+        result = job.result(timeout=20)
         self.assertIsInstance(result, Result)
 
     @requires_qe_access

--- a/test/python/test_ibmqjob.py
+++ b/test/python/test_ibmqjob.py
@@ -21,7 +21,7 @@ import qiskit._compiler
 from qiskit.backends.ibmq import IBMQProvider
 from qiskit.backends.ibmq.ibmqjob import IBMQJob, IBMQJobError
 from qiskit.backends.ibmq.ibmqbackend import IBMQBackendError
-from qiskit.backends.basejob import JobStatus
+from qiskit.backends import JobStatus
 from .common import requires_qe_access, QiskitTestCase, slow_test
 
 
@@ -156,7 +156,7 @@ class TestIBMQJob(QiskitTestCase):
                                    '{0} s'.format(timeout))
             time.sleep(0.2)
 
-        result_array = [job.result(qobj=qobj) for job in job_array]
+        result_array = [job.result() for job in job_array]
         self.log.info('got back all job results')
         # Ensure all jobs have finished.
         self.assertTrue(all([job.done for job in job_array]))
@@ -202,7 +202,7 @@ class TestIBMQJob(QiskitTestCase):
         self.assertTrue(num_jobs - num_error - num_done > 0)
 
         # Wait for all the results.
-        result_array = [job.result(qobj=qobj) for job in job_array]
+        result_array = [job.result() for job in job_array]
 
         # Ensure all jobs have finished.
         self.assertTrue(all([job.done for job in job_array]))

--- a/test/python/test_ibmqjob.py
+++ b/test/python/test_ibmqjob.py
@@ -105,7 +105,7 @@ class TestIBMQJob(QiskitTestCase):
         if job.exception:
             raise job.exception
         self.log.info(job.status)
-        result = job.result()
+        result = job.result(qobj=qobj)
         counts_qx = result.get_counts(result.get_names()[0])
         counts_ex = {'00': shots/2, '11': shots/2}
         states = counts_qx.keys() | counts_ex.keys()
@@ -156,7 +156,7 @@ class TestIBMQJob(QiskitTestCase):
                                    '{0} s'.format(timeout))
             time.sleep(0.2)
 
-        result_array = [job.result() for job in job_array]
+        result_array = [job.result(qobj=qobj) for job in job_array]
         self.log.info('got back all job results')
         # Ensure all jobs have finished.
         self.assertTrue(all([job.done for job in job_array]))
@@ -202,7 +202,7 @@ class TestIBMQJob(QiskitTestCase):
         self.assertTrue(num_jobs - num_error - num_done > 0)
 
         # Wait for all the results.
-        result_array = [job.result() for job in job_array]
+        result_array = [job.result(qobj=qobj) for job in job_array]
 
         # Ensure all jobs have finished.
         self.assertTrue(all([job.done for job in job_array]))
@@ -272,9 +272,7 @@ class TestIBMQJob(QiskitTestCase):
         self.log.info('found %s jobs on backend %s', len(job_list), backend.name)
         for job in job_list:
             self.log.info('status: %s', job.status)
-            result = job.result()
-            for circuit_name in result.get_names():
-                self.log.info(result.get_data(circuit_name=circuit_name))
+            self.assertTrue(isinstance(job.job_id, str))
 
     def test_retrieve_job(self):
         backend = self._provider.get_backend('ibmq_qasm_simulator')

--- a/test/python/test_ibmqjob.py
+++ b/test/python/test_ibmqjob.py
@@ -105,7 +105,7 @@ class TestIBMQJob(QiskitTestCase):
         if job.exception:
             raise job.exception
         self.log.info(job.status)
-        result = job.result(qobj=qobj)
+        result = job.result()
         counts_qx = result.get_counts(result.get_names()[0])
         counts_ex = {'00': shots/2, '11': shots/2}
         states = counts_qx.keys() | counts_ex.keys()

--- a/test/python/test_ibmqjob.py
+++ b/test/python/test_ibmqjob.py
@@ -23,6 +23,8 @@ from qiskit.backends.ibmq.ibmqjob import IBMQJob, IBMQJobError
 from qiskit.backends.basejob import JobStatus
 from .common import requires_qe_access, QiskitTestCase, slow_test
 
+USING_HUB = False
+
 
 def lowest_pending_jobs(backends):
     """Returns the backend with lowest pending jobs."""

--- a/test/python/test_ibmqjob.py
+++ b/test/python/test_ibmqjob.py
@@ -266,13 +266,15 @@ class TestIBMQJob(QiskitTestCase):
         self.assertTrue(job.backend_name == backend_name)
 
     def test_get_jobs_from_backend(self):
-        backends = self._provider.available_backends({'simulator': False})
+        backends = self._provider.available_backends()
         backend = lowest_pending_jobs(backends)
         job_list = backend.jobs(limit=5, skip=0)
         self.log.info('found %s jobs on backend %s', len(job_list), backend.name)
         for job in job_list:
             self.log.info('status: %s', job.status)
-        self.assertTrue(job_list)
+            result = job.result()
+            for circuit_name in result.get_names():
+                self.log.info(result.get_data(circuit_name=circuit_name))
 
     def test_retrieve_job(self):
         backend = self._provider.get_backend('ibmq_qasm_simulator')
@@ -281,6 +283,7 @@ class TestIBMQJob(QiskitTestCase):
         job = backend.run(quantum_job)
         rjob = backend.retrieve_job(job.job_id)
         self.assertTrue(job.job_id == rjob.job_id)
+        self.assertTrue(job.result().get_counts() == rjob.result().get_counts())
 
     def test_retrieve_job_error(self):
         backends = self._provider.available_backends({'simulator': False})

--- a/test/python/test_ibmqjob.py
+++ b/test/python/test_ibmqjob.py
@@ -238,8 +238,6 @@ class TestIBMQJob(QiskitTestCase):
         qobj = qiskit._compiler.compile(self._qc, backend)
         quantum_job = QuantumJob(qobj, backend, preformatted=True)
         job = backend.run(quantum_job)
-        while job.status['status'] == JobStatus.INITIALIZING:
-            time.sleep(0.1)
         self.log.info('job_id: %s', job.job_id)
         self.assertTrue(job.job_id is not None)
 
@@ -261,12 +259,12 @@ class TestIBMQJob(QiskitTestCase):
         self.assertTrue(job_list)
 
     def test_retrieve_job(self):
-        backends = self._provider.available_backends({'simulator': False})
-        backend = lowest_pending_jobs(backends)
-        job_list = backend.jobs(limit=1, skip=0)
-        job_id = job_list[0].job_id
-        job = backend.retrieve_job(job_id)
-        self.assertTrue(job_id == job.job_id)
+        backend = self._provider.get_backend('ibmq_qasm_simulator')
+        qobj = qiskit._compiler.compile(self._qc, backend)
+        quantum_job = QuantumJob(qobj, backend, preformatted=True)
+        job = backend.run(quantum_job)
+        rjob = backend.retrieve_job(job.job_id)
+        self.assertTrue(job.job_id == rjob.job_id)
 
     def test_retrieve_job_error(self):
         backends = self._provider.available_backends({'simulator': False})

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -1511,7 +1511,7 @@ class TestQuantumProgram(QiskitTestCase):
 
         result = q_program.execute(circuits, backend='local_qasm_simulator')
 
-        yvals, xvals = result.get_qubitpol_vs_xval(xvals_dict=xvals_dict)
+        yvals, xvals = result.get_qubitpol_vs_xval(2, xvals_dict=xvals_dict)
 
         self.assertTrue(np.array_equal(yvals, [[-1, -1], [1, -1]]))
         self.assertTrue(np.array_equal(xvals, [0, 1]))

--- a/test/python/test_reordering.py
+++ b/test/python/test_reordering.py
@@ -13,7 +13,7 @@ import unittest
 import qiskit
 from qiskit import QuantumJob
 from qiskit.wrapper import register, available_backends, get_backend
-from qiskit.wrapper import compile as qcompile
+from qiskit.wrapper import compile
 from .common import requires_qe_access, QiskitTestCase, slow_test
 
 
@@ -50,13 +50,13 @@ class TestBitReordering(QiskitTestCase):
         circ.measure(q[1], c[0])
 
         shots = 2000
-        qobj_real = qcompile(circ, real, shots=shots)
-        qobj_sim = qcompile(circ, sim, shots=shots)
+        qobj_real = compile(circ, real, shots=shots)
+        qobj_sim = compile(circ, sim, shots=shots)
         q_job_real = QuantumJob(qobj_real, backend=real, preformatted=True,
                                 shots=shots)
         q_job_sim = QuantumJob(qobj_sim, backend=sim, preformatted=True,
                                shots=shots)
-        result_real = real.run(q_job_real).result(timeout=600, qobj=qobj_real)
+        result_real = real.run(q_job_real).result(timeout=600)
         result_sim = sim.run(q_job_sim).result(timeout=600)
         counts_real = result_real.get_counts()
         counts_sim = result_sim.get_counts()
@@ -97,13 +97,13 @@ class TestBitReordering(QiskitTestCase):
         circ.measure(q2[0], c1[1])
 
         shots = 4000
-        qobj_real = qcompile(circ, real, shots=shots)
-        qobj_sim = qcompile(circ, sim, shots=shots)
+        qobj_real = compile(circ, real, shots=shots)
+        qobj_sim = compile(circ, sim, shots=shots)
         q_job_real = QuantumJob(qobj_real, backend=real, preformatted=True,
                                 shots=shots)
         q_job_sim = QuantumJob(qobj_sim, backend=sim, preformatted=True,
                                shots=shots)
-        result_real = real.run(q_job_real).result(timeout=600, qobj=qobj_real)
+        result_real = real.run(q_job_real).result(timeout=600)
         result_sim = sim.run(q_job_sim).result(timeout=600)
         counts_real = result_real.get_counts()
         counts_sim = result_sim.get_counts()

--- a/test/python/test_reordering.py
+++ b/test/python/test_reordering.py
@@ -13,7 +13,6 @@ import unittest
 import qiskit
 from qiskit import QuantumJob
 from qiskit.wrapper import register, available_backends, get_backend
-from qiskit.wrapper import compile
 from .common import requires_qe_access, QiskitTestCase, slow_test
 
 
@@ -50,8 +49,6 @@ class TestBitReordering(QiskitTestCase):
         circ.measure(q[1], c[0])
 
         shots = 2000
-        qobj_real = compile(circ, real, shots=shots)
-        qobj_sim = compile(circ, sim, shots=shots)
         q_job_real = QuantumJob(qobj_real, backend=real, preformatted=True,
                                 shots=shots)
         q_job_sim = QuantumJob(qobj_sim, backend=sim, preformatted=True,
@@ -97,8 +94,6 @@ class TestBitReordering(QiskitTestCase):
         circ.measure(q2[0], c1[1])
 
         shots = 4000
-        qobj_real = compile(circ, real, shots=shots)
-        qobj_sim = compile(circ, sim, shots=shots)
         q_job_real = QuantumJob(qobj_real, backend=real, preformatted=True,
                                 shots=shots)
         q_job_sim = QuantumJob(qobj_sim, backend=sim, preformatted=True,

--- a/test/python/test_reordering.py
+++ b/test/python/test_reordering.py
@@ -13,6 +13,7 @@ import unittest
 import qiskit
 from qiskit import QuantumJob
 from qiskit.wrapper import register, available_backends, get_backend
+from qiskit.wrapper import compile
 from .common import requires_qe_access, QiskitTestCase, slow_test
 
 
@@ -49,6 +50,8 @@ class TestBitReordering(QiskitTestCase):
         circ.measure(q[1], c[0])
 
         shots = 2000
+        qobj_real = compile(circ, real, shots=shots)
+        qobj_sim = compile(circ, sim, shots=shots)
         q_job_real = QuantumJob(qobj_real, backend=real, preformatted=True,
                                 shots=shots)
         q_job_sim = QuantumJob(qobj_sim, backend=sim, preformatted=True,
@@ -94,6 +97,8 @@ class TestBitReordering(QiskitTestCase):
         circ.measure(q2[0], c1[1])
 
         shots = 4000
+        qobj_real = compile(circ, real, shots=shots)
+        qobj_sim = compile(circ, sim, shots=shots)
         q_job_real = QuantumJob(qobj_real, backend=real, preformatted=True,
                                 shots=shots)
         q_job_sim = QuantumJob(qobj_sim, backend=sim, preformatted=True,

--- a/test/python/test_reordering.py
+++ b/test/python/test_reordering.py
@@ -11,7 +11,9 @@
 
 import unittest
 import qiskit
-from qiskit.wrapper import register, available_backends, get_backend, execute
+from qiskit import QuantumJob
+from qiskit.wrapper import register, available_backends, get_backend
+from qiskit.wrapper import compile as qcompile
 from .common import requires_qe_access, QiskitTestCase, slow_test
 
 
@@ -34,10 +36,12 @@ class TestBitReordering(QiskitTestCase):
     @requires_qe_access
     def test_basic_reordering(self, QE_TOKEN, QE_URL, hub=None, group=None, project=None):
         """a simple reordering within a 2-qubit register"""
-        sim, real = self._get_backends(QE_TOKEN, QE_URL, hub, group, project)
+        sim_backend_name, real_backend_name = self._get_backends(
+            QE_TOKEN, QE_URL, hub, group, project)
+        sim = get_backend(sim_backend_name)
+        real = get_backend(real_backend_name)
         if not sim or not real:
             raise unittest.SkipTest('no remote device available')
-
         q = qiskit.QuantumRegister(2)
         c = qiskit.ClassicalRegister(2)
         circ = qiskit.QuantumCircuit(q, c)
@@ -46,8 +50,14 @@ class TestBitReordering(QiskitTestCase):
         circ.measure(q[1], c[0])
 
         shots = 2000
-        result_real = execute(circ, real, {"shots": shots}).result(timeout=600)
-        result_sim = execute(circ, sim, {"shots": shots}).result()
+        qobj_real = qcompile(circ, real, shots=shots)
+        qobj_sim = qcompile(circ, sim, shots=shots)
+        q_job_real = QuantumJob(qobj_real, backend=real, preformatted=True,
+                                shots=shots)
+        q_job_sim = QuantumJob(qobj_sim, backend=sim, preformatted=True,
+                               shots=shots)
+        result_real = real.run(q_job_real).result(timeout=600, qobj=qobj_real)
+        result_sim = sim.run(q_job_sim).result(timeout=600)
         counts_real = result_real.get_counts()
         counts_sim = result_sim.get_counts()
         self.log.info(counts_real)
@@ -57,11 +67,15 @@ class TestBitReordering(QiskitTestCase):
 
     @slow_test
     @requires_qe_access
-    def test_multi_register_reordering(self, QE_TOKEN, QE_URL, hub=None, group=None, project=None):
+    def test_multi_register_reordering(self, QE_TOKEN, QE_URL,
+                                       hub=None, group=None, project=None):
         """a more complicated reordering across 3 registers of different sizes"""
-        sim, real = self._get_backends(QE_TOKEN, QE_URL, hub, group, project)
-        if not sim or not real:
+        sim_backend_name, real_backend_name = self._get_backends(
+            QE_TOKEN, QE_URL, hub, group, project)
+        if not sim_backend_name or not real_backend_name:
             raise unittest.SkipTest('no remote device available')
+        sim = get_backend(sim_backend_name)
+        real = get_backend(real_backend_name)
 
         q0 = qiskit.QuantumRegister(2)
         q1 = qiskit.QuantumRegister(2)
@@ -83,8 +97,14 @@ class TestBitReordering(QiskitTestCase):
         circ.measure(q2[0], c1[1])
 
         shots = 4000
-        result_real = execute(circ, real, {"shots": shots}).result(timeout=600)
-        result_sim = execute(circ, sim, {"shots": shots}).result()
+        qobj_real = qcompile(circ, real, shots=shots)
+        qobj_sim = qcompile(circ, sim, shots=shots)
+        q_job_real = QuantumJob(qobj_real, backend=real, preformatted=True,
+                                shots=shots)
+        q_job_sim = QuantumJob(qobj_sim, backend=sim, preformatted=True,
+                               shots=shots)
+        result_real = real.run(q_job_real).result(timeout=600, qobj=qobj_real)
+        result_sim = sim.run(q_job_sim).result(timeout=600)
         counts_real = result_real.get_counts()
         counts_sim = result_sim.get_counts()
         threshold = 0.2 * shots

--- a/test/python/test_reordering.py
+++ b/test/python/test_reordering.py
@@ -13,7 +13,7 @@ import unittest
 import qiskit
 from qiskit import QuantumJob
 from qiskit.wrapper import register, available_backends, get_backend
-from qiskit.wrapper import compile
+import qiskit._compiler
 from .common import requires_qe_access, QiskitTestCase, slow_test
 
 
@@ -50,8 +50,8 @@ class TestBitReordering(QiskitTestCase):
         circ.measure(q[1], c[0])
 
         shots = 2000
-        qobj_real = compile(circ, real, shots=shots)
-        qobj_sim = compile(circ, sim, shots=shots)
+        qobj_real = qiskit._compiler.compile(circ, real, shots=shots)
+        qobj_sim = qiskit._compiler.compile(circ, sim, shots=shots)
         q_job_real = QuantumJob(qobj_real, backend=real, preformatted=True,
                                 shots=shots)
         q_job_sim = QuantumJob(qobj_sim, backend=sim, preformatted=True,
@@ -97,8 +97,8 @@ class TestBitReordering(QiskitTestCase):
         circ.measure(q2[0], c1[1])
 
         shots = 4000
-        qobj_real = compile(circ, real, shots=shots)
-        qobj_sim = compile(circ, sim, shots=shots)
+        qobj_real = qiskit._compiler.compile(circ, real, shots=shots)
+        qobj_sim = qiskit._compiler.compile(circ, sim, shots=shots)
         q_job_real = QuantumJob(qobj_real, backend=real, preformatted=True,
                                 shots=shots)
         q_job_sim = QuantumJob(qobj_sim, backend=sim, preformatted=True,


### PR DESCRIPTION
Some things you can find in this PR:
* In general, reduce the number of requests send to the API
* Jobs with multiple circtuits can be used with their respective
  results
* Instantiating a IBMQJob doesn't imply to submit the information.
  There's a separate method: .submit() that will make this
  operation explicit to the user.
* Fixing some incorrect status handling
* Removed active polling in some situations (time.sleep(0.1))
* Refactored _wait_for_job() for simplicity
* Removed IBMQJob.exception()
* Reduced some algorithm complexity

It will probably require a second iteration to polish some things.
