### PR TITLE
Add check that decomposition includes qsd2q gates before optimizing them

### DIFF
--- a/qiskit/quantum_info/synthesis/qsd.py
+++ b/qiskit/quantum_info/synthesis/qsd.py
@@ -237,6 +237,8 @@ def _apply_a2(circ):
         instr, _, _ = instr_context
         if instr.name == "qsd2q":
             ind2q.append(i)
+    if not ind2q:
+        return ccirc
     # rolling over diagonals
     ind2 = None  # lint
     for ind1, ind2 in zip(ind2q[0:-1:], ind2q[1::]):

--- a/test/python/quantum_info/test_synthesis.py
+++ b/test/python/quantum_info/test_synthesis.py
@@ -1542,9 +1542,17 @@ class TestQuantumShannonDecomposer(QiskitTestCase):
             ccirc.count_ops().get("cx"), (23 / 48) * 4**nqubits - (3 / 2) * 2**nqubits + 4 / 3
         )
 
+    # 10036
     def test_1q_decomposition(self):
         """Test decomposition of single qubit matrix"""
         mat = np.array([[0, 1], [1, 0]])
+        circ = self.qsd(mat)
+        self.assertEqual(Operator(mat), Operator(circ))
+
+    # 10036
+    def test_2q_with_no_qsd2q(self):
+        """Test decomposition of unitary whose decomposition is all "u" and "cx"."""
+        mat = CXGate().to_matrix()
         circ = self.qsd(mat)
         self.assertEqual(Operator(mat), Operator(circ))
 


### PR DESCRIPTION
The PR #10126 still allows some 2q unitaries to fail. The commit here prevents these (all I know of) failures.

Adds a fix and test for a 2q unitary that failed with on the branch that this PR is made to.